### PR TITLE
switch to using typelib's value and valuevisitor types so we get the …

### DIFF
--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -449,7 +449,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
     }
 
     depth += 1;
-    auto retval = Typelib::ValueVisitor::visit_(v, type);
+    bool retval = Typelib::ValueVisitor::visit_(v, type);
     depth -= 1;
 
     return retval;
@@ -468,7 +468,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Array const& type)
     msgpack_pack_array(&pk, type.getDimension());
 
     depth += 1;
-    auto retval = Typelib::ValueVisitor::visit_(v, type);
+    bool retval = Typelib::ValueVisitor::visit_(v, type);
     depth -= 1;
 
     return retval;
@@ -539,7 +539,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type)
     msgpack_pack_map(&pk, type.getFields().size());
 
     depth += 1;
-    auto retval = Typelib::ValueVisitor::visit_(v, type);
+    bool retval = Typelib::ValueVisitor::visit_(v, type);
     depth -= 1;
 
     return retval;
@@ -559,7 +559,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type, T
     fieldName.push_back(field.getName());
 
     depth += 1;
-    auto retval = Typelib::ValueVisitor::visit_(v, type, field);
+    bool retval = Typelib::ValueVisitor::visit_(v, type, field);
     depth -= 1;
 
     fieldName.pop_back();

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -21,7 +21,7 @@ void addValidInputDataStreams(
     const std::string& only);
 int convertStreams(
     msgpack_packer& packer, std::vector<pocolog_cpp::InputDataStream*>& dataStreams,
-    const int size, const int containerLimit, const int start, const int end,
+    const int containerLimit, const int start, const int end,
     const int verbose);
 int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
                    const int start, const int end, const int verbose);
@@ -31,7 +31,7 @@ int convertMetaData(
 
 
 int convert(const std::vector<std::string>& logfiles, const std::string& output,
-            const int size, const int containerLimit, const std::string& only,
+            const int containerLimit, const std::string& only,
             const int start, const int end, const int verbose)
 {
     pocolog_cpp::MultiFileIndex* multiIndex = new pocolog_cpp::MultiFileIndex();
@@ -52,7 +52,7 @@ int convert(const std::vector<std::string>& logfiles, const std::string& output,
     msgpack_pack_map(&packer, 2 * dataStreams.size());
 
     int exitStatus = convertStreams(
-                         packer, dataStreams, size, containerLimit, start, end, verbose);
+                         packer, dataStreams, containerLimit, start, end, verbose);
     exitStatus += convertMetaData(
                       packer, dataStreams, start, end, verbose);
 
@@ -108,7 +108,7 @@ const int computeRangeEnd(const int userStart, const int userEnd,
 
 int convertStreams(
     msgpack_packer& packer, std::vector<pocolog_cpp::InputDataStream*>& dataStreams,
-    const int size, const int containerLimit, const int start, const int end,
+    const int containerLimit, const int start, const int end,
     const int verbose)
 {
     int exitStatus = EXIT_SUCCESS;

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -185,9 +185,9 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
             for ( size_t i=0; i < curSampleData.size() ; i++ )
             {
                 if (i % 32 == 0) std::cout << std::endl;
-                std::ios_base::fmtflags f( std::cout.flags() );
+                std::ios_base::fmtflags f(std::cout.flags());
                 std::cout << std::setfill('0') << std::setw(2) << std::right << std::hex << (unsigned int)(curSampleData[i]) << " ";
-                std::cout.flags( f );
+                std::cout.flags(f);
                 std::cout << " ";
 
                 if (i > 128)

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -41,7 +41,7 @@ int convert(const std::vector<std::string>& logfiles, const std::string& output,
     addValidInputDataStreams(streams, dataStreams, only);
     if(verbose >= 1)
         std::cout << "[pocolog2msgpack] " << dataStreams.size() << " streams"
-            << std::endl;
+                  << std::endl;
 
     FILE* fp = fopen(output.c_str(), "w");
 
@@ -52,9 +52,9 @@ int convert(const std::vector<std::string>& logfiles, const std::string& output,
     msgpack_pack_map(&packer, 2 * dataStreams.size());
 
     int exitStatus = convertStreams(
-        packer, dataStreams, size, containerLimit, start, end, verbose);
+                         packer, dataStreams, size, containerLimit, start, end, verbose);
     exitStatus += convertMetaData(
-        packer, dataStreams, start, end, verbose);
+                      packer, dataStreams, start, end, verbose);
 
     fclose(fp);
     delete multiIndex;
@@ -78,14 +78,14 @@ void addValidInputDataStreams(
         if(!dataStream)
         {
             std::cerr << "[pocolog2msgpack] Stream #" << i
-                << " is not an InputDataStream, will be ignored!" << std::endl;
+                      << " is not an InputDataStream, will be ignored!" << std::endl;
             continue;
         }
         dataStreams.push_back(dataStream);
     }
     if(only != "" && dataStreams.size() == 0)
         std::cerr << "[pocolog2msgpack] Did not find the stream '" << only
-            << "'." << std::endl;
+                  << "'." << std::endl;
 }
 
 const int computeRangeEnd(const int userStart, const int userEnd,
@@ -97,9 +97,9 @@ const int computeRangeEnd(const int userStart, const int userEnd,
         if(printWarning)
         {
             std::cerr << "[pocolog2msgpack] Requested samples [" << userStart
-                << ", " << userEnd << "). This stream only has "
-                << streamLength << " samples. Range will be cut to ["
-                << userStart << ", " << streamLength << ")" << std::endl;
+                      << ", " << userEnd << "). This stream only has "
+                      << streamLength << " samples. Range will be cut to ["
+                      << userStart << ", " << streamLength << ")" << std::endl;
         }
         realEnd = streamLength;
     }
@@ -121,13 +121,14 @@ int convertStreams(
         const std::string streamName = stream->getName();
         if(verbose >= 1)
             std::cout << "[pocolog2msgpack] Stream #" << i << " ("
-                << streamName << "): " << stream->getSize()
-                << " samples" << std::endl;
+                      << streamName << "): " << stream->getSize()
+                      << " samples" << std::endl;
 
         const int realEnd = computeRangeEnd(start, end, stream->getSize(), true);
         int exportedSize = realEnd - start;
 
-        if (exportedSize < 0) {
+        if (exportedSize < 0)
+        {
             std::cerr << "[pocolog2msgpack] No samples in requested range for stream \""
                       << streamName << "\"." << std::endl;
             exportedSize = 0;
@@ -150,7 +151,7 @@ int convertStreams(
 }
 
 int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
-    const int start, const int end, const int verbose)
+                   const int start, const int end, const int verbose)
 {
 
     float next_report_progress = 0.0;
@@ -159,9 +160,10 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
     for(size_t t = start; t < end; t++)
     {
 
-        if(verbose >= 2) {
+        if(verbose >= 2)
+        {
             std::cout << "[pocolog2msgpack] Converting sample #" << t
-                << std::endl;
+                      << std::endl;
         }
         std::vector<uint8_t> curSampleData;
         const bool ok = stream->getSampleData(curSampleData, t);
@@ -169,23 +171,27 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
         if(!ok)
         {
             std::cerr << "[pocolog2msgpack] ERROR: Could not read sample data."
-                << std::endl;
+                      << std::endl;
             return EXIT_FAILURE;
         }
 
-        if(verbose >= 3) {
+        if(verbose >= 3)
+        {
             std::cout << "Converting sample of size " << curSampleData.size() << std::endl;
         }
 
-        if(verbose >= 4){
-            for ( size_t i=0; i < curSampleData.size() ; i++ ){
+        if(verbose >= 4)
+        {
+            for ( size_t i=0; i < curSampleData.size() ; i++ )
+            {
                 if (i % 32 == 0) std::cout << std::endl;
                 std::ios_base::fmtflags f( std::cout.flags() );
                 std::cout << std::setfill('0') << std::setw(2) << std::right << std::hex << (unsigned int)(curSampleData[i]) << " ";
                 std::cout.flags( f );
                 std::cout << " ";
 
-                if (i > 128) {
+                if (i > 128)
+                {
                     std::cout << "...";
                     break;
                 }
@@ -197,9 +203,11 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
 
         float progress = ((float)(t-start))/(end-start);
 
-        if ( progress >= next_report_progress ) {
+        if ( progress >= next_report_progress )
+        {
             next_report_progress += report_progress_delta;
-            if (verbose >= 1) {
+            if (verbose >= 1)
+            {
                 std::cout << "[pocolog2msgpack] " << (int)(progress*100) << "% of stream done." << std::endl;
             }
         }
@@ -228,7 +236,8 @@ int convertMetaData(
         const int realEnd = computeRangeEnd(start, end, stream->getSize(), false);
         int exportedSize = realEnd - start;
 
-        if (exportedSize < 0) {
+        if (exportedSize < 0)
+        {
             std::cerr << "[pocolog2msgpack] No samples in requested range for meta stream \""
                       << key << "\"." << std::endl;
             exportedSize = 0;
@@ -245,8 +254,9 @@ int convertMetaData(
 
         msgpack_pack_array(&packer, exportedSize);
 
-        if (exportedSize > 0) {
-            for(size_t t = start; t < realEnd; t++) 
+        if (exportedSize > 0)
+        {
+            for(size_t t = start; t < realEnd; t++)
             {
                 msgpack_pack_int64(&packer, streamIndex.getSampleTime(t).microseconds);
             }
@@ -299,17 +309,19 @@ void Converter::reset()
 void Converter::printBegin()
 {
     std::cout << "[pocolog2msgpack]"
-        << std::setfill(' ') << std::setw(indentation + depth) << " ";
+              << std::setfill(' ') << std::setw(indentation + depth) << " ";
 }
 
-bool Converter::visit_ (int8_t  & v) 
+bool Converter::visit_ (int8_t  & v)
 {
-    if (debug) {
+    if (debug)
+    {
         printBegin();
         std::cout << "got int8 " << (int)v << std::endl;
     }
 
-    if (mode_numeric_to_string) {
+    if (mode_numeric_to_string)
+    {
         numeric_to_string_buffer += (char)v;
         return true;
     }
@@ -318,15 +330,15 @@ bool Converter::visit_ (int8_t  & v)
     return true;
 }
 
-bool Converter::visit_ (uint8_t & v) 
+bool Converter::visit_ (uint8_t & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << "got uint8 " << (unsigned int) v << std::endl;
     }
 
-    if (mode_numeric_to_string) 
+    if (mode_numeric_to_string)
     {
         numeric_to_string_buffer += (char)v;
         return true;
@@ -336,9 +348,9 @@ bool Converter::visit_ (uint8_t & v)
     return true;
 }
 
-bool Converter::visit_ (int16_t & v) 
+bool Converter::visit_ (int16_t & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(int16_t & v) got "<<  v  << std::endl;
@@ -346,9 +358,9 @@ bool Converter::visit_ (int16_t & v)
     msgpack_pack_int16(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint16_t& v) 
+bool Converter::visit_ (uint16_t& v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(uint16_t& v) got "<<  v  << std::endl;
@@ -356,9 +368,9 @@ bool Converter::visit_ (uint16_t& v)
     msgpack_pack_uint16(&pk, v);
     return true;
 }
-bool Converter::visit_ (int32_t & v) 
+bool Converter::visit_ (int32_t & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(int32_t & v) got "<<  v  << std::endl;
@@ -366,9 +378,9 @@ bool Converter::visit_ (int32_t & v)
     msgpack_pack_int32(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint32_t& v) 
+bool Converter::visit_ (uint32_t& v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(uint32_t& v) got "<<  v  << std::endl;
@@ -376,9 +388,9 @@ bool Converter::visit_ (uint32_t& v)
     msgpack_pack_uint32(&pk, v);
     return true;
 }
-bool Converter::visit_ (int64_t & v) 
+bool Converter::visit_ (int64_t & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(int64_t & v) got "<<  v  << std::endl;
@@ -386,18 +398,19 @@ bool Converter::visit_ (int64_t & v)
     msgpack_pack_int64(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint64_t& v) 
+bool Converter::visit_ (uint64_t& v)
 {
-    if (debug) {
+    if (debug)
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(uint64_t& v) got "<<  v  << std::endl;
     }
     msgpack_pack_uint64(&pk, v);
     return true;
 }
-bool Converter::visit_ (float   & v) 
+bool Converter::visit_ (float   & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(float   & v) got "<<  v  << std::endl;
@@ -405,9 +418,9 @@ bool Converter::visit_ (float   & v)
     msgpack_pack_float(&pk, v);
     return true;
 }
-bool Converter::visit_ (double  & v) 
+bool Converter::visit_ (double  & v)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "(double  & v) got "<<  v  << std::endl;
@@ -419,7 +432,7 @@ bool Converter::visit_ (double  & v)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::OpaqueType const& type)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "OpaqueType at "<< v.getData() << std::endl;
@@ -429,7 +442,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::OpaqueType const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "Pointer at "<< v.getData() <<   std::endl;
@@ -444,7 +457,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Array const& type)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << __FUNCTION__ << "Array at "<< v.getData() <<  std::endl;
@@ -465,14 +478,17 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 {
     size_t numElements = type.getElementCount(v.getData());
 
-    if (debug) 
+    if (debug)
     {
-        printBegin(); std::cout << __FUNCTION__ << "Container at "<< v.getData() << std::endl;
-        printBegin(); std::cout << "numElements: " <<numElements << std::endl;
-        printBegin(); std::cout << type.kind() << "[" << numElements << "]" << std::endl;
+        printBegin();
+        std::cout << __FUNCTION__ << "Container at "<< v.getData() << std::endl;
+        printBegin();
+        std::cout << "numElements: " <<numElements << std::endl;
+        printBegin();
+        std::cout << type.kind() << "[" << numElements << "]" << std::endl;
     }
 
-    if(numElements > containerLimit) 
+    if(numElements > containerLimit)
     {
         throw std::runtime_error("too many elements");
     }
@@ -490,14 +506,16 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
         mode_numeric_to_string = false;
 
-        if (debug) {
+        if (debug)
+        {
             std::cout << "got str: \"" << numeric_to_string_buffer << "\""  << std::endl;
         }
 
         msgpack_pack_str(&pk, numeric_to_string_buffer.size());
         msgpack_pack_str_body(&pk, numeric_to_string_buffer.c_str(), numeric_to_string_buffer.size());
 
-    } else 
+    }
+    else
     {
 
         msgpack_pack_array(&pk, numElements);
@@ -512,7 +530,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << "compound '" << type.getName() << "' with " << type.getFields().size() << " fields" << std::endl;
@@ -529,7 +547,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type, Typelib::Field const& field)
 {
-    if (debug) 
+    if (debug)
     {
         printBegin();
         std::cout << "field '" << field.getName() << "'" << std::endl;
@@ -549,7 +567,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type, T
     return retval;
 }
 
-bool Converter::visit_(Typelib::Enum::integral_type& intValue, Typelib::Enum const& e) {
+bool Converter::visit_(Typelib::Enum::integral_type& intValue, Typelib::Enum const& e)
+{
     try
     {
         std::string value = e.get(intValue);
@@ -561,7 +580,7 @@ bool Converter::visit_(Typelib::Enum::integral_type& intValue, Typelib::Enum con
     {
         msgpack_pack_int(&pk, intValue);
         std::cerr << "[pocolog2msgpack] Could not find a string representation "
-            << "for enum value " << intValue << "." << std::endl;
+                  << "for enum value " << intValue << "." << std::endl;
     }
 
     return true;

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -154,8 +154,8 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
                    const int start, const int end, const int verbose)
 {
 
-    float next_report_progress = 0.0;
-    float report_progress_delta = 0.1;
+    float nextReportProgress = 0.0;
+    float reportProgressDelta = 0.1;
 
     for(size_t t = start; t < end; t++)
     {
@@ -203,9 +203,9 @@ int convertSamples(Converter& conv, pocolog_cpp::InputDataStream* stream,
 
         float progress = ((float)(t-start))/(end-start);
 
-        if ( progress >= next_report_progress )
+        if ( progress >= nextReportProgress )
         {
-            next_report_progress += report_progress_delta;
+            nextReportProgress += reportProgressDelta;
             if (verbose >= 1)
             {
                 std::cout << "[pocolog2msgpack] " << (int)(progress*100) << "% of stream done." << std::endl;
@@ -320,9 +320,9 @@ bool Converter::visit_ (int8_t  & v)
         std::cout << "got int8 " << (int)v << std::endl;
     }
 
-    if (mode_numeric_to_string)
+    if (modeNumericToString)
     {
-        numeric_to_string_buffer += (char)v;
+        numericToStringBuffer += (char)v;
         return true;
     }
 
@@ -338,9 +338,9 @@ bool Converter::visit_ (uint8_t & v)
         std::cout << "got uint8 " << (unsigned int) v << std::endl;
     }
 
-    if (mode_numeric_to_string)
+    if (modeNumericToString)
     {
-        numeric_to_string_buffer += (char)v;
+        numericToStringBuffer += (char)v;
         return true;
     }
 
@@ -497,22 +497,22 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
     if(type.kind() == "/std/string")
     {
-        numeric_to_string_buffer = "";
-        mode_numeric_to_string = true;
+        numericToStringBuffer = "";
+        modeNumericToString = true;
 
         depth += 1;
         retval = Typelib::ValueVisitor::visit_(v, type);
         depth -= 1;
 
-        mode_numeric_to_string = false;
+        modeNumericToString = false;
 
         if (debug)
         {
-            std::cout << "got str: \"" << numeric_to_string_buffer << "\""  << std::endl;
+            std::cout << "got str: \"" << numericToStringBuffer << "\""  << std::endl;
         }
 
-        msgpack_pack_str(&pk, numeric_to_string_buffer.size());
-        msgpack_pack_str_body(&pk, numeric_to_string_buffer.c_str(), numeric_to_string_buffer.size());
+        msgpack_pack_str(&pk, numericToStringBuffer.size());
+        msgpack_pack_str_body(&pk, numericToStringBuffer.c_str(), numericToStringBuffer.size());
 
     }
     else

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -274,7 +274,6 @@ Converter::Converter(std::string const& basename, Typelib::Type const& type, msg
 
 Converter::~Converter()
 {
-    assert(!data);
 }
 
 void Converter::convertSample(std::vector<uint8_t>& data)

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -312,7 +312,7 @@ void Converter::printBegin()
               << std::setfill(' ') << std::setw(indentation + depth) << " ";
 }
 
-bool Converter::visit_ (int8_t  & v)
+bool Converter::visit_ (int8_t & v)
 {
     if (debug)
     {
@@ -353,17 +353,17 @@ bool Converter::visit_ (int16_t & v)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(int16_t & v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(int16_t & v) got " << v << std::endl;
     }
     msgpack_pack_int16(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint16_t& v)
+bool Converter::visit_ (uint16_t & v)
 {
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(uint16_t& v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(uint16_t & v) got " << v << std::endl;
     }
     msgpack_pack_uint16(&pk, v);
     return true;
@@ -373,7 +373,7 @@ bool Converter::visit_ (int32_t & v)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(int32_t & v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(int32_t & v) got " << v << std::endl;
     }
     msgpack_pack_int32(&pk, v);
     return true;
@@ -383,7 +383,7 @@ bool Converter::visit_ (uint32_t& v)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(uint32_t& v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(uint32_t& v) got " << v << std::endl;
     }
     msgpack_pack_uint32(&pk, v);
     return true;
@@ -393,7 +393,7 @@ bool Converter::visit_ (int64_t & v)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(int64_t & v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(int64_t & v) got " << v << std::endl;
     }
     msgpack_pack_int64(&pk, v);
     return true;
@@ -403,27 +403,27 @@ bool Converter::visit_ (uint64_t& v)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(uint64_t& v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(uint64_t& v) got " << v << std::endl;
     }
     msgpack_pack_uint64(&pk, v);
     return true;
 }
-bool Converter::visit_ (float   & v)
+bool Converter::visit_ (float & v)
 {
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(float   & v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(float & v) got " << v << std::endl;
     }
     msgpack_pack_float(&pk, v);
     return true;
 }
-bool Converter::visit_ (double  & v)
+bool Converter::visit_ (double & v)
 {
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "(double  & v) got "<<  v  << std::endl;
+        std::cout << __FUNCTION__ << "(double & v) got " << v << std::endl;
     }
     msgpack_pack_double(&pk, v);
 
@@ -435,7 +435,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::OpaqueType const& type)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "OpaqueType at "<< v.getData() << std::endl;
+        std::cout << __FUNCTION__ << "OpaqueType at " << v.getData() << std::endl;
     }
     return true;
 }
@@ -445,7 +445,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "Pointer at "<< v.getData() <<   std::endl;
+        std::cout << __FUNCTION__ << "Pointer at " << v.getData() << std::endl;
     }
 
     depth += 1;
@@ -460,7 +460,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Array const& type)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "Array at "<< v.getData() <<  std::endl;
+        std::cout << __FUNCTION__ << "Array at " << v.getData() << std::endl;
         printBegin();
         std::cout << "array[" << type.getDimension() << "]" << std::endl;
     }
@@ -481,7 +481,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
     if (debug)
     {
         printBegin();
-        std::cout << __FUNCTION__ << "Container at "<< v.getData() << std::endl;
+        std::cout << __FUNCTION__ << "Container at " << v.getData() << std::endl;
         printBegin();
         std::cout << "numElements: " <<numElements << std::endl;
         printBegin();
@@ -508,7 +508,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
         if (debug)
         {
-            std::cout << "got str: \"" << numericToStringBuffer << "\""  << std::endl;
+            std::cout << "got str: \"" << numericToStringBuffer << "\"" << std::endl;
         }
 
         msgpack_pack_str(&pk, numericToStringBuffer.size());

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -246,7 +246,8 @@ int convertMetaData(
         msgpack_pack_array(&packer, exportedSize);
 
         if (exportedSize > 0) {
-            for(size_t t = start; t < realEnd; t++) {
+            for(size_t t = start; t < realEnd; t++) 
+            {
                 msgpack_pack_int64(&packer, streamIndex.getSampleTime(t).microseconds);
             }
         }
@@ -301,7 +302,8 @@ void Converter::printBegin()
         << std::setfill(' ') << std::setw(indentation + depth) << " ";
 }
 
-bool Converter::visit_ (int8_t  & v) {
+bool Converter::visit_ (int8_t  & v) 
+{
     if (debug) {
         printBegin();
         std::cout << "got int8 " << (int)v << std::endl;
@@ -316,13 +318,16 @@ bool Converter::visit_ (int8_t  & v) {
     return true;
 }
 
-bool Converter::visit_ (uint8_t & v) {
-    if (debug) {
+bool Converter::visit_ (uint8_t & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << "got uint8 " << (unsigned int) v << std::endl;
     }
 
-    if (mode_numeric_to_string) {
+    if (mode_numeric_to_string) 
+    {
         numeric_to_string_buffer += (char)v;
         return true;
     }
@@ -331,47 +336,58 @@ bool Converter::visit_ (uint8_t & v) {
     return true;
 }
 
-bool Converter::visit_ (int16_t & v) {
-    if (debug) {
+bool Converter::visit_ (int16_t & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(int16_t & v) got "<<  v  << std::endl;
     }
     msgpack_pack_int16(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint16_t& v) {
-    if (debug) {
+bool Converter::visit_ (uint16_t& v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(uint16_t& v) got "<<  v  << std::endl;
     }
     msgpack_pack_uint16(&pk, v);
     return true;
 }
-bool Converter::visit_ (int32_t & v) {
-    if (debug) {
+bool Converter::visit_ (int32_t & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(int32_t & v) got "<<  v  << std::endl;
     }
     msgpack_pack_int32(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint32_t& v) {
-    if (debug) {
+bool Converter::visit_ (uint32_t& v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(uint32_t& v) got "<<  v  << std::endl;
     }
     msgpack_pack_uint32(&pk, v);
     return true;
 }
-bool Converter::visit_ (int64_t & v) {
-    if (debug) {
+bool Converter::visit_ (int64_t & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(int64_t & v) got "<<  v  << std::endl;
     }
     msgpack_pack_int64(&pk, v);
     return true;
 }
-bool Converter::visit_ (uint64_t& v) {
+bool Converter::visit_ (uint64_t& v) 
+{
     if (debug) {
         printBegin();
         std::cout << __FUNCTION__ << "(uint64_t& v) got "<<  v  << std::endl;
@@ -379,16 +395,20 @@ bool Converter::visit_ (uint64_t& v) {
     msgpack_pack_uint64(&pk, v);
     return true;
 }
-bool Converter::visit_ (float   & v) {
-    if (debug) {
+bool Converter::visit_ (float   & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(float   & v) got "<<  v  << std::endl;
     }
     msgpack_pack_float(&pk, v);
     return true;
 }
-bool Converter::visit_ (double  & v) {
-    if (debug) {
+bool Converter::visit_ (double  & v) 
+{
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "(double  & v) got "<<  v  << std::endl;
     }
@@ -399,7 +419,8 @@ bool Converter::visit_ (double  & v) {
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::OpaqueType const& type)
 {
-    if (debug) {
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "OpaqueType at "<< v.getData() << std::endl;
     }
@@ -408,7 +429,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::OpaqueType const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
 {
-    if (debug) {
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "Pointer at "<< v.getData() <<   std::endl;
     }
@@ -422,7 +444,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Pointer const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Array const& type)
 {
-    if (debug) {
+    if (debug) 
+    {
         printBegin();
         std::cout << __FUNCTION__ << "Array at "<< v.getData() <<  std::endl;
         printBegin();
@@ -442,13 +465,15 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 {
     size_t numElements = type.getElementCount(v.getData());
 
-    if (debug) {
+    if (debug) 
+    {
         printBegin(); std::cout << __FUNCTION__ << "Container at "<< v.getData() << std::endl;
         printBegin(); std::cout << "numElements: " <<numElements << std::endl;
         printBegin(); std::cout << type.kind() << "[" << numElements << "]" << std::endl;
     }
 
-    if(numElements > containerLimit) {
+    if(numElements > containerLimit) 
+    {
         throw std::runtime_error("too many elements");
     }
 
@@ -472,7 +497,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
         msgpack_pack_str(&pk, numeric_to_string_buffer.size());
         msgpack_pack_str_body(&pk, numeric_to_string_buffer.c_str(), numeric_to_string_buffer.size());
 
-    } else {
+    } else 
+    {
 
         msgpack_pack_array(&pk, numElements);
 
@@ -486,7 +512,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type)
 {
-    if (debug) {
+    if (debug) 
+    {
         printBegin();
         std::cout << "compound '" << type.getName() << "' with " << type.getFields().size() << " fields" << std::endl;
     }
@@ -502,7 +529,8 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type)
 
 bool Converter::visit_(Typelib::Value const& v, Typelib::Compound const& type, Typelib::Field const& field)
 {
-    if (debug) {
+    if (debug) 
+    {
         printBegin();
         std::cout << "field '" << field.getName() << "'" << std::endl;
     }

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -483,7 +483,7 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
         printBegin();
         std::cout << __FUNCTION__ << "Container at " << v.getData() << std::endl;
         printBegin();
-        std::cout << "numElements: " <<numElements << std::endl;
+        std::cout << "numElements: " << numElements << std::endl;
         printBegin();
         std::cout << type.kind() << "[" << numElements << "]" << std::endl;
     }

--- a/src/Converter.cpp
+++ b/src/Converter.cpp
@@ -490,7 +490,11 @@ bool Converter::visit_(Typelib::Value const& v, Typelib::Container const& type)
 
     if(numElements > containerLimit)
     {
-        throw std::runtime_error("too many elements");
+        std::cerr << "[pocolog2msgpack] Container size " << numElements 
+                  << " exceeds limit of " << containerLimit << ". Skipping..."
+                  << std::endl;
+                  
+        return false;
     }
 
     bool retval = false;

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -49,9 +49,9 @@ class Converter : public Typelib::ValueVisitor
     /** A constant that will be used to format debug output on stdout. */
     const int indentation;
 
-    bool mode_numeric_to_string = false;
+    bool modeNumericToString = false;
 
-    std::string numeric_to_string_buffer = "";
+    std::string numericToStringBuffer = "";
 
 public:
     Converter(std::string const& basename, Typelib::Type const& type, msgpack_packer& pk, int containerLimit, int verbose);

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -48,11 +48,11 @@ class Converter : public Typelib::ValueVisitor
     int depth;
     /** A constant that will be used to format debug output on stdout. */
     const int indentation;
-    
+
     bool mode_numeric_to_string = false;
-    
+
     std::string numeric_to_string_buffer = "";
-    
+
 public:
     Converter(std::string const& basename, Typelib::Type const& type, msgpack_packer& pk, int containerLimit, int verbose);
     virtual ~Converter();
@@ -68,7 +68,7 @@ protected:
     bool visit_ (uint64_t& v);
     bool visit_ (float   & v);
     bool visit_ (double  & v);
-    
+
     bool visit_(Typelib::Value const& v, Typelib::OpaqueType const& type);
     bool visit_(Typelib::Value const& v, Typelib::Pointer const& type);
     bool visit_(Typelib::Value const& v, Typelib::Array const& type);
@@ -76,7 +76,7 @@ protected:
     bool visit_(Typelib::Value const& v, Typelib::Compound const& type);
     bool visit_(Typelib::Value const& v, Typelib::Compound const& type, Typelib::Field const& field);
     bool visit_(Typelib::Enum::integral_type&, Typelib::Enum const& e);
-    
+
     using ValueVisitor::visit_;
 private:
     void reset();

--- a/src/Converter.hpp
+++ b/src/Converter.hpp
@@ -10,7 +10,6 @@
  * Convert logfile.
  * @param logfiles names of the pocolog logfiles
  * @param output name of the MsgPack logfile, will be created
- * @param size size of the size type for containers in the logfile
  * @param containerLimit maximum lenght of a container that will be converted
  * @param only only convert the port given by this argument
  * @param start index of the first sample that will be exported
@@ -19,7 +18,7 @@
  * @return exit status of the program
  */
 int convert(const std::vector<std::string>& logfiles, const std::string& output,
-            const int size, const int containerLimit, const std::string& only,
+            const int containerLimit, const std::string& only,
             const int start, const int end, const int verbose);
 
 

--- a/src/pocolog2msgpack.cpp
+++ b/src/pocolog2msgpack.cpp
@@ -20,9 +20,6 @@ int main(int argc, char *argv[])
             "Logfiles")
         ("output,o", boost::program_options::value<std::string>()->default_value("output.msg"),
             "Output file")
-        ("size,s", boost::program_options::value<int>()->default_value(8),
-            "Length of the size type. This should be 8 for most machines, "
-            "but it can be 1, e.g. on robots.")
         ("container-limit,c", boost::program_options::value<int>()->default_value(10000),
             "Maximum length of a container that will be read and converted. "
             "This option should only be used if you have old logfiles from "
@@ -58,7 +55,6 @@ int main(int argc, char *argv[])
     const int verbose = vm["verbose"].as<int>();
     const std::vector<std::string> logfiles = vm["logfile"].as<std::vector<std::string> >();
     const std::string output = vm["output"].as<std::string>();
-    const int size = vm["size"].as<int>();
     const int containerLimit = vm["container-limit"].as<int>();
     const std::string only = vm["only"].as<std::string>();
     const int start = vm["start"].as<int>();
@@ -81,6 +77,6 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    return convert(logfiles, output, size, containerLimit, only, start, end,
+    return convert(logfiles, output, containerLimit, only, start, end,
                    verbose);
 }


### PR DESCRIPTION
…resulting data directly without further raw data parsing;
fix empty range selection;
add progress output

This should fix issue #6 by using typelib's load function.
We cannot cast directly log data to types, the data has to be loaded since the binary representation may differ (such as for vectors). This also removes a lot of duplicate code.
I'm not 100% sure the init of the typelib value is supposed to be done like that,
but it works and valgrind doesn't complain.
