### PR TITLE
python installation improvements (using Autoproj)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ your manifest:
        - tools/pocolog2msgpack
        ...
 
+**Important** when installing the library through Autproj, the Python part of this library and the correspondent python dependencies will only get installed if in your Autoproj settings the USE_PYTHON flag is set to true.
+
 ## Usage
 
 This repository contains a program that will convert files from the pocolog log format to MessagePack format. It is called `pocolog2msgpack`. These are its options:

--- a/manifest.xml
+++ b/manifest.xml
@@ -17,7 +17,6 @@
   <depend package="python3-setuptools" optional="1" />
   <depend package="python3-nose" optional="1" />
   <depend package="python3-pexpect" optional="1" />
-  <depend package="python3-msgpack" optional="1" />
   <depend package="python3-pip" optional="1" />
 
   <keywords>

--- a/python-pocolog2msgpack/tests/test_pocolog2msgpack.py
+++ b/python-pocolog2msgpack/tests/test_pocolog2msgpack.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-from pocolog2msgpack import pocolog2msgpack
+import pocolog2msgpack
 
 
 class TestPocolog2msgpack(unittest.TestCase):


### PR DESCRIPTION
The manifest.xml triggers the install of an incompatible python-msgpack version. 

Since the installation through autoproj already installs the dependencies through the requirements.txt the line is not needed in the manifest.

The import of the test gives an error as it is currently.
```
Traceback (most recent call last):
  File "tools/pocolog2msgpack/python-pocolog2msgpack/tests/test_pocolog2msgpack.py", line 8, in <module>
    import pocolog2msgpack
ModuleNotFoundError: No module named 'pocolog2msgpack'
```
The fix removes the error.